### PR TITLE
docs: list all slash commands

### DIFF
--- a/reconcile_bot/README.md
+++ b/reconcile_bot/README.md
@@ -4,7 +4,8 @@ A modular, JSON-backed Discord bot that lets groups collaborate on documents via
 
 ## Features
 
-• Slash commands: `/create_group`, `/join_group`, `/list_groups`, `/create_document`, `/list_documents`, `/view_document`, `/recommend`  
+• Slash commands: `/create_group`, `/join_group`, `/list_groups`, `/create_document`, `/list_documents`, `/view_document`,
+  `/recommend`, `/my_groups`, `/reconcile`, `/reconcile_status`, `/reconcile_cancel`, `/doc_create`
 • Proposals: open a modal to submit content changes and vote Accept/Reject with buttons  
 • Simple merge rule: a proposal merges when it has more accepts than rejects and at least a simple majority of current group members have accepted  
 • JSON persistence so state survives restarts  


### PR DESCRIPTION
## Summary
- document all registered slash commands in README

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError / SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6899022a65548322a5932660d596bca8