### PR TITLE
Disallow voting on merged proposals and ensure imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+"""Test configuration for ensuring package imports.
+
+This repository does not use a ``src`` layout and the tests are located in a
+separate directory.  When ``pytest`` is executed as a console script the current
+working directory might not be automatically added to ``sys.path`` which can
+lead to ``ModuleNotFoundError`` for the ``reconcile_bot`` package.  To provide a
+stable testing environment we explicitly insert the repository root into
+``sys.path`` before any tests are collected.
+"""
+
+import os
+import sys
+
+
+# Add the repository root (the directory containing this file) to ``sys.path``
+# if it is not already present.  This mirrors the behaviour of running the
+# tests via ``python -m pytest`` where the working directory is automatically on
+# the import path.
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+

--- a/reconcile_bot/data/store.py
+++ b/reconcile_bot/data/store.py
@@ -277,6 +277,12 @@ class ReconcileStore:
         if not proposal:
             return "Proposal not found."
 
+        # Reject any further voting once the proposal has been merged.  The
+        # test-suite expects a clear message to be returned instead of silently
+        # recording additional votes, which was the previous behaviour.
+        if proposal.merged:
+            return "This proposal has already been merged."
+
         # record vote
         proposal.votes[user_id] = vote
 


### PR DESCRIPTION
## Summary
- prevent new votes on proposals once merged with an explanatory message
- add test configuration to place repository root on `sys.path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990681a2e88322bb82abf2e8cfec28