### PR TITLE
Use timezone-aware UTC timestamps

### DIFF
--- a/reconcile_bot/bot.py
+++ b/reconcile_bot/bot.py
@@ -22,6 +22,7 @@ class ReconcileBot(commands.Bot):
 
 from discord.ext import tasks
 import datetime
+from datetime import UTC
 
 class _StoreHolder:
     store: ReconcileStore | None = None
@@ -37,7 +38,7 @@ async def _update_reconcile_messages(bot: ReconcileBot):
     from .ui.views import reconcile_embed, VoteView
     for rec in store.list_open_reconciles():
         # reminders at 24h and 1h
-        remaining = rec.close_ts - datetime.datetime.utcnow().timestamp()
+        remaining = rec.close_ts - datetime.datetime.now(tz=UTC).timestamp()
 
 # reminders
 if 60*59 < remaining <= 60*61 and not getattr(rec, "reminded_1", False):  # ~1h

--- a/reconcile_bot/data/store.py
+++ b/reconcile_bot/data/store.py
@@ -15,6 +15,7 @@ kept as it existed conceptually in the repository but in a much cleaner form.
 from __future__ import annotations
 
 import datetime
+from datetime import UTC
 import json
 import os
 from typing import Dict, List, Optional, Set, Tuple
@@ -257,7 +258,7 @@ class ReconcileStore:
             proposal_id=pid,
             author_id=author_id,
             content=content,
-            timestamp=datetime.datetime.utcnow().timestamp(),
+            timestamp=datetime.datetime.now(tz=UTC).timestamp(),
             votes={},
             merged=False,
         )
@@ -334,7 +335,7 @@ class ReconcileStore:
     ) -> int:
         self._ensure_reconciles_loaded()
         rid = self.next_reconcile_id()
-        now = datetime.datetime.utcnow().timestamp()
+        now = datetime.datetime.now(tz=UTC).timestamp()
         close_ts = now + duration_hours * 3600
         rec = Reconcile(
             reconcile_id=rid,
@@ -385,7 +386,7 @@ class ReconcileStore:
             voter_id=voter_id,
             side=side,
             score=score,
-            timestamp=datetime.datetime.utcnow().timestamp(),
+            timestamp=datetime.datetime.now(tz=UTC).timestamp(),
 
         )
         self.save()


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` calls with `datetime.datetime.now(tz=UTC)`
- import `UTC` and use timezone-aware timestamps in bot and store modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990863bf008322baf8f8f4143ceae0