### PR TITLE
Fix indentation bug in bot and add compile test

### DIFF
--- a/reconcile_bot/bot.py
+++ b/reconcile_bot/bot.py
@@ -1,62 +1,105 @@
+"""Discord bot implementation for the reconciliation workflow.
+
+This module previously contained a large block of code that had lost all
+indentation.  Python therefore raised an ``IndentationError`` whenever the
+module was imported which is why ``python -m reconcile_bot.main`` failed.  The
+tests never imported this module so the issue slipped through.  The file has
+been rewritten with proper structure and a small test now compiles it to catch
+similar problems in the future.
+"""
+
 from __future__ import annotations
-import asyncio
+
+import datetime
+
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
+
 from .logging_config import setup_logging
+from .data.store import ReconcileStore
+
 
 class ReconcileBot(commands.Bot):
-    def __init__(self, **kwargs):
+    """Small ``discord.py`` based bot used for running reconciliations."""
+
+    background_task: tasks.Loop | None
+
+    def __init__(self, **kwargs) -> None:  # pragma: no cover - trivial
         intents = kwargs.pop("intents", None) or discord.Intents.default()
-        # We use slash commands and components; message content intent not needed
+        # We use slash commands and components; message content intent not
+        # needed.
         intents.message_content = False
         super().__init__(command_prefix=kwargs.pop("command_prefix", "!"), intents=intents)
         self.log = setup_logging()
+        self.background_task = None
 
     async def setup_hook(self) -> None:
-        # Could register persistent views here if needed
-        pass
+        """Register background tasks when the bot starts."""
 
-    async def on_ready(self) -> None:
-        await self.change_presence(activity=discord.Game(name="/create_group • /join_group • /view_document"))
+        # Periodically update open reconciliation messages.
+        self.background_task = tasks.Loop(
+            _update_reconcile_messages,
+            seconds=60.0,
+            count=None,
+            reconnect=True,
+            kwargs={"bot": self},
+        )
+        self.background_task.start()
+        await super().setup_hook()
+
+    async def on_ready(self) -> None:  # pragma: no cover - requires discord
+        await self.change_presence(activity=discord.Game(name="Reconcile"))
         self.log.info("Logged in as %s (%s)", self.user, self.user.id if self.user else "?")
 
-from discord.ext import tasks
-import datetime
 
 class _StoreHolder:
+    """Simple indirection so the store can be attached after creation."""
+
     store: ReconcileStore | None = None
+
 
 STORE_HOLDER = _StoreHolder()
 
-def attach_store(store: ReconcileStore):
+
+def attach_store(store: ReconcileStore) -> None:
     STORE_HOLDER.store = store
 
-async def _update_reconcile_messages(bot: ReconcileBot):
+
+async def _update_reconcile_messages(bot: ReconcileBot) -> None:
+    """Background task for refreshing and closing reconcile messages."""
+
     store = STORE_HOLDER.store
-    if not store: return
-    from .ui.views import reconcile_embed, VoteView
+    if not store:
+        return
+
+    from .ui.views import VoteView, reconcile_embed
+
     for rec in store.list_open_reconciles():
-        # reminders at 24h and 1h
         remaining = rec.close_ts - datetime.datetime.utcnow().timestamp()
 
-# reminders
-if 60*59 < remaining <= 60*61 and not getattr(rec, "reminded_1", False):  # ~1h
-    ch = bot.get_channel(rec.channel_id)
-    if ch and rec.thread_id:
-        thread = await ch.fetch_channel(rec.thread_id)
-        await thread.send("⏰ Final reminder: 1 hour left to vote.")
-    rec.reminded_1 = True
-    store.save()
-if 60*60*23 < remaining <= 60*60*25 and not getattr(rec, "reminded_24", False):  # ~24h
-    ch = bot.get_channel(rec.channel_id)
-    if ch and rec.thread_id:
-        thread = await ch.fetch_channel(rec.thread_id)
-        await thread.send("⏰ Reminder: 24 hours left to vote.")
-    rec.reminded_24 = True
-    store.save()
-if remaining < 0 and not rec.closed:
+        # ------------------------------------------------------------------
+        # Reminder messages at ~24h and ~1h before closing
+        # ------------------------------------------------------------------
+        if 60 * 59 < remaining <= 60 * 61 and not getattr(rec, "reminded_1", False):
+            ch = bot.get_channel(rec.channel_id)
+            if ch and rec.thread_id:
+                thread = await ch.fetch_channel(rec.thread_id)
+                await thread.send("⏰ Final reminder: 1 hour left to vote.")
+            rec.reminded_1 = True
+            store.save()
 
-            # close and post result
+        if 60 * 60 * 23 < remaining <= 60 * 60 * 25 and not getattr(rec, "reminded_24", False):
+            ch = bot.get_channel(rec.channel_id)
+            if ch and rec.thread_id:
+                thread = await ch.fetch_channel(rec.thread_id)
+                await thread.send("⏰ Reminder: 24 hours left to vote.")
+            rec.reminded_24 = True
+            store.save()
+
+        # ------------------------------------------------------------------
+        # Close reconciles that have expired
+        # ------------------------------------------------------------------
+        if remaining < 0 and not rec.closed:
             ch = bot.get_channel(rec.channel_id)
             if ch and rec.thread_id:
                 thread = await ch.fetch_channel(rec.thread_id)
@@ -66,7 +109,10 @@ if remaining < 0 and not rec.closed:
                 await thread.send(embed=e)
             store.close_reconcile(rec.reconcile_id)
             continue
-        # refresh tally embed
+
+        # ------------------------------------------------------------------
+        # Otherwise refresh the tally message if we have one
+        # ------------------------------------------------------------------
         if rec.thread_id and rec.message_id:
             ch = bot.get_channel(rec.channel_id)
             if not ch:
@@ -74,19 +120,17 @@ if remaining < 0 and not rec.closed:
             try:
                 thread = await ch.fetch_channel(rec.thread_id)
                 msg = await thread.fetch_message(rec.message_id)
-                await msg.edit(embed=reconcile_embed(store, rec.reconcile_id), view=VoteView(store, rec.reconcile_id, rec.a_side, rec.b_side))
-            except Exception:
+                await msg.edit(
+                    embed=reconcile_embed(store, rec.reconcile_id),
+                    view=VoteView(store, rec.reconcile_id, rec.a_side, rec.b_side),
+                )
+            except Exception:  # pragma: no cover - best effort
                 pass
 
-class ReconcileBot(commands.Bot):
-    background_task: tasks.Loop
 
-    async def setup_hook(self) -> None:
-        # Register persistent views if any in future; start background loops
-        self.background_task = tasks.Loop(_update_reconcile_messages, seconds=60.0, count=None, reconnect=True, kwargs={"bot": self})
-        self.background_task.start()
-        await super().setup_hook()
+__all__ = [
+    "ReconcileBot",
+    "attach_store",
+    "_update_reconcile_messages",
+]
 
-    async def on_ready(self) -> None:
-        await self.change_presence(activity=discord.Game(name="Reconcile"))
-        self.log.info("Logged in as %s (%s)", self.user, self.user.id if self.user else "?")

--- a/reconcile_bot/main.py
+++ b/reconcile_bot/main.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
-import asyncio, sys
+
+import asyncio
 import discord
+
 from .bot import ReconcileBot, attach_store
+from .commands.register import register_commands
 from .config import load_settings
 from .data.store import ReconcileStore
-from .commands.register import register_commands
 from .logging_config import setup_logging
 
 def main() -> int:

--- a/tests/test_bot_compile.py
+++ b/tests/test_bot_compile.py
@@ -1,0 +1,17 @@
+import py_compile
+from pathlib import Path
+
+
+def test_bot_and_main_compile() -> None:
+    """The Discord bot modules should at least be syntactically valid.
+
+    Previously ``reconcile_bot.bot`` had lost indentation which meant importing
+    it (for example via ``python -m reconcile_bot.main``) crashed with an
+    ``IndentationError``.  Compiling the modules here ensures a regression would
+    be caught by the test-suite without requiring the ``discord`` package to be
+    installed.
+    """
+
+    py_compile.compile(Path("reconcile_bot/bot.py"), doraise=True)
+    py_compile.compile(Path("reconcile_bot/main.py"), doraise=True)
+


### PR DESCRIPTION
## Summary
- Rewrite `reconcile_bot.bot` with proper indentation and structure
- Tidy `main` imports
- Add tests that compile bot and main modules to catch syntax/indentation regressions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689908becf4c8322b8b9a5da247d7b1d