### PR TITLE
fix: remove kwargs from Loop initialization

### DIFF
--- a/reconcile_bot/bot.py
+++ b/reconcile_bot/bot.py
@@ -43,9 +43,8 @@ class ReconcileBot(commands.Bot):
             seconds=60.0,
             count=None,
             reconnect=True,
-            kwargs={"bot": self},
         )
-        self.background_task.start()
+        self.background_task.start(self)
         await super().setup_hook()
 
     async def on_ready(self) -> None:  # pragma: no cover - requires discord


### PR DESCRIPTION
## Summary
- fix ReconcileBot setup to pass bot instance to Loop.start and avoid unsupported kwargs

## Testing
- `pytest -q`
- `python -m reconcile_bot.main` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68991122d79883229a3ae3f2c564acbe