### PR TITLE
Ensure reconcile channels on startup

### DIFF
--- a/reconcile_bot/bot.py
+++ b/reconcile_bot/bot.py
@@ -18,6 +18,7 @@ import datetime
 from datetime import UTC
 from .logging_config import setup_logging
 from .data.store import ReconcileStore
+from .commands.utils import ensure_channels
 
 
 class ReconcileBot(commands.Bot):
@@ -57,6 +58,15 @@ class ReconcileBot(commands.Bot):
         tree = getattr(self, "tree", None)
         if tree is not None:  # pragma: no cover - exercised in integration
             await tree.sync()
+
+        for guild in self.guilds:
+            try:  # pragma: no cover - best effort during startup
+                await ensure_channels(guild)
+            except Exception:  # pragma: no cover - avoid failing startup
+                self.log.exception(
+                    "Failed to ensure reconcile channels for guild %s",
+                    getattr(guild, "id", "?"),
+                )
 
         await super().setup_hook()
 

--- a/reconcile_bot/commands/register.py
+++ b/reconcile_bot/commands/register.py
@@ -166,10 +166,15 @@ def register_commands(bot: commands.Bot, store: ReconcileStore) -> None:
             await interaction.response.send_message("Use the picker to select mode and groups.", view=reconcile_picker_view(store, interaction.guild.id), ephemeral=True)
             return
         # ensure channels exist
-        docs_id, votes_id = await ensure_channels(interaction.guild)
-        rid = store.create_reconcile(mode, your_group if mode=="group↔group" else f"solo:{interaction.user.display_name}", target_group, interaction.guild.id, votes_id)
+        _, votes_ch = await ensure_channels(interaction.guild)
+        rid = store.create_reconcile(
+            mode,
+            your_group if mode == "group↔group" else f"solo:{interaction.user.display_name}",
+            target_group,
+            interaction.guild.id,
+            votes_ch.id,
+        )
         # create thread and initial embed
-        votes_ch = interaction.guild.get_channel(votes_id)
         title = f"Reconcile: {your_group} ↔ {target_group}" if mode=="group↔group" else f"Reconcile: {interaction.user.display_name} → {target_group}"
         thread = await votes_ch.create_thread(name=title, type=discord.ChannelType.public_thread)
         from ..ui.views import VoteView, reconcile_embed

--- a/reconcile_bot/commands/utils.py
+++ b/reconcile_bot/commands/utils.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import discord
 
-async def ensure_channels(guild: discord.Guild) -> tuple[int, int]:
+
+async def ensure_channels(
+    guild: discord.Guild,
+) -> tuple[discord.TextChannel, discord.TextChannel]:
     """Ensure the reconciliation channels exist in ``guild``.
 
-    Returns a tuple of ``(docs_channel_id, votes_channel_id)``.
+    Returns a tuple of ``(docs_channel, votes_channel)``.
     """
+
     docs = discord.utils.get(guild.text_channels, name="reconcile-docs")
     votes = discord.utils.get(guild.text_channels, name="reconcile-votes")
     if docs is None:
         docs = await guild.create_text_channel("reconcile-docs")
     if votes is None:
         votes = await guild.create_text_channel("reconcile-votes")
-    return docs.id, votes.id
+    return docs, votes

--- a/reconcile_bot/ui/modals.py
+++ b/reconcile_bot/ui/modals.py
@@ -42,8 +42,7 @@ class DocumentModal(discord.ui.Modal, title="Create Document"):
             return
 
         try:
-            docs_id, _ = await ensure_channels(guild)
-            docs_ch = guild.get_channel(docs_id)
+            docs_ch, _ = await ensure_channels(guild)
 
             from .views import DocumentView
 

--- a/tests/test_bot_setup_hook.py
+++ b/tests/test_bot_setup_hook.py
@@ -42,7 +42,7 @@ def test_setup_hook_uses_tasks_loop(monkeypatch) -> None:
 
     class Bot:  # pragma: no cover - trivial container for required API
         def __init__(self, *args, **kwargs) -> None:
-            pass
+            self.guilds = []
 
         async def setup_hook(self) -> None:
             pass
@@ -71,6 +71,8 @@ def test_setup_hook_uses_tasks_loop(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "discord.ext", ext)
     monkeypatch.setitem(sys.modules, "discord.ext.commands", commands)
     monkeypatch.setitem(sys.modules, "discord.ext.tasks", tasks)
+    monkeypatch.delitem(sys.modules, "reconcile_bot.commands.utils", raising=False)
+    monkeypatch.delitem(sys.modules, "reconcile_bot.bot", raising=False)
 
     # Import after stubbing modules to ensure ``reconcile_bot.bot`` uses them
     from reconcile_bot.bot import ReconcileBot
@@ -81,3 +83,94 @@ def test_setup_hook_uses_tasks_loop(monkeypatch) -> None:
     # ``AttributeError`` (which would happen if ``tasks.Loop`` were used).
     asyncio.run(bot.setup_hook())
 
+
+def test_setup_hook_creates_channels(monkeypatch) -> None:
+    # ------------------------------------------------------------------
+    # Create minimal ``discord`` package with channel utilities
+    # ------------------------------------------------------------------
+    discord = types.ModuleType("discord")
+
+    class Intents:
+        message_content: bool = False
+
+        @staticmethod
+        def default() -> "Intents":  # pragma: no cover - simple stub
+            return Intents()
+
+    discord.Intents = Intents
+
+    def utils_get(seq, **attrs):
+        for item in seq:
+            if all(getattr(item, k, None) == v for k, v in attrs.items()):
+                return item
+        return None
+
+    discord.utils = types.SimpleNamespace(get=utils_get)
+
+    ext = types.ModuleType("discord.ext")
+    commands = types.ModuleType("discord.ext.commands")
+    tasks = types.ModuleType("discord.ext.tasks")
+
+    class Bot:  # pragma: no cover - trivial container for required API
+        def __init__(self, *args, **kwargs) -> None:
+            self.guilds = []
+
+        async def setup_hook(self) -> None:
+            pass
+
+        async def change_presence(self, *_, **__) -> None:
+            pass
+
+    commands.Bot = Bot
+
+    def loop(*_args, **_kwargs):
+        def decorator(func):
+            class DummyLoop:
+                def start(self, *a, **kw):  # pragma: no cover - trivial
+                    pass
+
+            return DummyLoop()
+
+        return decorator
+
+    tasks.loop = loop
+
+    ext.commands = commands
+    ext.tasks = tasks
+
+    monkeypatch.setitem(sys.modules, "discord", discord)
+    monkeypatch.setitem(sys.modules, "discord.utils", discord.utils)
+    monkeypatch.setitem(sys.modules, "discord.ext", ext)
+    monkeypatch.setitem(sys.modules, "discord.ext.commands", commands)
+    monkeypatch.setitem(sys.modules, "discord.ext.tasks", tasks)
+    monkeypatch.delitem(sys.modules, "reconcile_bot.commands.utils", raising=False)
+    monkeypatch.delitem(sys.modules, "reconcile_bot.bot", raising=False)
+
+    # Import after stubbing modules
+    from reconcile_bot.bot import ReconcileBot
+
+    class Channel:
+        def __init__(self, name, cid):
+            self.name = name
+            self.id = cid
+
+    class Guild:
+        def __init__(self):
+            self.text_channels = []
+            self._next = 1
+
+        async def create_text_channel(self, name):
+            ch = Channel(name, self._next)
+            self._next += 1
+            self.text_channels.append(ch)
+            return ch
+
+    guild = Guild()
+
+    bot = ReconcileBot()
+    bot.guilds = [guild]
+
+    asyncio.run(bot.setup_hook())
+
+    names = sorted(ch.name for ch in guild.text_channels)
+    assert names == ["reconcile-docs", "reconcile-votes"]


### PR DESCRIPTION
## Summary
- call ensure_channels for each guild when bot starts
- return channel objects from ensure_channels and reuse for previews and threads
- add integration test for startup channel creation
- log any channel setup failures instead of silently swallowing exceptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68992a458624832287bbad7fcc25a333