### PR TITLE
Add core models and Discord adapter with tests

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /tests

--- a/reconcile_bot/__init__.py
+++ b/reconcile_bot/__init__.py
@@ -1,0 +1,13 @@
+"""Core package for Reconcile.
+
+This module exposes the main data models and storage layer so that
+consumers of the package can simply import them from ``reconcile_bot``.
+
+The project is intentionally small at this stage; additional modules will
+build upon these foundations in future iterations.
+"""
+
+from .core.models import Collaborator, Organization
+from .core.storage import JSONStorage
+
+__all__ = ["Collaborator", "Organization", "JSONStorage"]

--- a/reconcile_bot/adapters/base.py
+++ b/reconcile_bot/adapters/base.py
@@ -1,0 +1,17 @@
+"""Base adapter interface for platform specific implementations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Adapter(ABC):
+    """Abstract adapter for communication platforms."""
+
+    @abstractmethod
+    async def send_message(self, channel_id: str, content: str) -> None:
+        """Send ``content`` to the specified ``channel_id``."""
+
+    @abstractmethod
+    async def create_text_channel(self, guild_id: str, name: str) -> str:
+        """Create a text channel and return its identifier."""

--- a/reconcile_bot/adapters/discord.py
+++ b/reconcile_bot/adapters/discord.py
@@ -1,0 +1,61 @@
+"""Discord adapter implementing the :class:`~reconcile_bot.adapters.base.Adapter`.
+
+The adapter is intentionally small and only supports the features required by
+the unit tests. It uses :mod:`httpx` to communicate with Discord's HTTP API
+which keeps the implementation dependency light while remaining fully
+asynchronous.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .base import Adapter
+
+
+class DiscordAdapter(Adapter):
+    """Adapter that sends requests directly to the Discord HTTP API."""
+
+    api_base = "https://discord.com/api"
+
+    def __init__(self, token: str, client: httpx.AsyncClient | None = None) -> None:
+        """Store authentication ``token`` and optional HTTP ``client``."""
+        self.token = token
+        self.client = client or httpx.AsyncClient()
+
+    # ------------------------------------------------------------------
+    async def send_message(self, channel_id: str, content: str) -> None:
+        """Send a message to a channel.
+
+        Parameters
+        ----------
+        channel_id:
+            Identifier of the Discord channel.
+        content:
+            Message body to send.
+
+        """
+        url = f"{self.api_base}/channels/{channel_id}/messages"
+        headers = {"Authorization": f"Bot {self.token}"}
+        payload = {"content": content}
+        response = await self.client.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+
+    async def create_text_channel(self, guild_id: str, name: str) -> str:
+        """Create a text channel within a guild.
+
+        Returns the identifier of the newly created channel.
+        """
+        url = f"{self.api_base}/guilds/{guild_id}/channels"
+        headers = {"Authorization": f"Bot {self.token}"}
+        payload = {"name": name, "type": 0}
+        response = await self.client.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        return str(data["id"])
+
+    async def close(self) -> None:
+        """Close the underlying :class:`httpx.AsyncClient`."""
+        await self.client.aclose()

--- a/reconcile_bot/core/models.py
+++ b/reconcile_bot/core/models.py
@@ -1,0 +1,49 @@
+"""Data models for Reconcile's core entities.
+
+The models are implemented using :mod:`pydantic` so that they provide
+runtime validation and convenient serialisation to and from dictionaries.
+Only a couple of fields are defined for now; more can be added as the
+project evolves.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class Collaborator(BaseModel):
+    """Represents an individual participating in Reconcile.
+
+    Attributes
+    ----------
+    id:
+        Internal unique identifier for the collaborator. Defaults to a
+        random UUID4 string.
+    discord_id:
+        The Discord user ID for cross-platform identity mapping.
+    name:
+        Display name of the collaborator.
+    mission_statement:
+        Optional mission statement provided during onboarding.
+    organization_ids:
+        A list of organisation identifiers the collaborator is affiliated
+        with.
+
+    """
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    discord_id: int
+    name: str
+    mission_statement: str | None = None
+    organization_ids: list[str] = Field(default_factory=list)
+
+
+class Organization(BaseModel):
+    """Represents a Discord guild participating in Reconcile."""
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    guild_id: int
+    name: str
+    mission_statement: str | None = None

--- a/reconcile_bot/core/storage.py
+++ b/reconcile_bot/core/storage.py
@@ -1,0 +1,82 @@
+"""Simple JSON-backed storage for Reconcile data models."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from .models import Collaborator, Organization
+
+
+class JSONStorage:
+    """Persist :class:`Collaborator` and :class:`Organization` data.
+
+    The storage is intentionally lightweight. Data is persisted to a single
+    JSON file on every mutation which keeps the implementation simple while
+    providing durability across process restarts.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initialise storage using JSON file at ``path``."""
+        self.path = path
+        self._collaborators: dict[str, Collaborator] = {}
+        self._organizations: dict[str, Organization] = {}
+        if path.exists():
+            self._load()
+        else:
+            self._save()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _load(self) -> None:
+        data = json.loads(self.path.read_text())
+        self._collaborators = {
+            item["id"]: Collaborator(**item) for item in data.get("collaborators", [])
+        }
+        self._organizations = {
+            item["id"]: Organization(**item) for item in data.get("organizations", [])
+        }
+
+    def _save(self) -> None:
+        data = {
+            "collaborators": [c.model_dump() for c in self._collaborators.values()],
+            "organizations": [o.model_dump() for o in self._organizations.values()],
+        }
+        self.path.write_text(json.dumps(data, indent=2))
+
+    # ------------------------------------------------------------------
+    # Collaborator operations
+    def add_collaborator(self, collaborator: Collaborator) -> None:
+        """Persist a new ``collaborator`` to storage."""
+        self._collaborators[collaborator.id] = collaborator
+        self._save()
+
+    def get_collaborator_by_discord(self, discord_id: int) -> Collaborator | None:
+        """Retrieve a collaborator by their Discord user ID."""
+        return next(
+            (c for c in self._collaborators.values() if c.discord_id == discord_id),
+            None,
+        )
+
+    def all_collaborators(self) -> Iterable[Collaborator]:
+        """Return an iterable of all stored collaborators."""
+        return self._collaborators.values()
+
+    # ------------------------------------------------------------------
+    # Organization operations
+    def add_organization(self, organization: Organization) -> None:
+        """Persist a new ``organization`` to storage."""
+        self._organizations[organization.id] = organization
+        self._save()
+
+    def get_organization_by_guild(self, guild_id: int) -> Organization | None:
+        """Look up an organization by its Discord guild ID."""
+        return next(
+            (o for o in self._organizations.values() if o.guild_id == guild_id),
+            None,
+        )
+
+    def all_organizations(self) -> Iterable[Organization]:
+        """Return an iterable of all stored organizations."""
+        return self._organizations.values()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ pytest-cov==5.0.0
 bandit==1.7.7
 pre-commit==3.7.1
 detect-secrets==1.5.0
+pydantic==2.7.1
+httpx==0.27.0

--- a/tests/test_discord_adapter.py
+++ b/tests/test_discord_adapter.py
@@ -1,0 +1,49 @@
+"""Tests for the :mod:`reconcile_bot.adapters.discord` module."""
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from reconcile_bot.adapters.discord import DiscordAdapter
+
+
+def run(coro: Any) -> Any:
+    """Run an async coroutine synchronously for tests."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_send_message_makes_correct_request() -> None:
+    """Ensure ``send_message`` posts the expected payload."""
+    captured: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return httpx.Response(200, json={"id": "123"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    adapter = DiscordAdapter("TOKEN", client=client)
+
+    run(adapter.send_message("chan", "hello"))
+
+    request = captured["request"]
+    assert request.headers["Authorization"] == "Bot TOKEN"
+    assert request.url.path.endswith("/channels/chan/messages")
+
+
+def test_create_text_channel_returns_id() -> None:
+    """``create_text_channel`` should return the new channel id."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/guilds/1/channels")
+        return httpx.Response(200, json={"id": "555"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    adapter = DiscordAdapter("TOKEN", client=client)
+
+    channel_id = run(adapter.create_text_channel("1", "general"))
+    assert channel_id == "555"
+
+    run(adapter.close())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,18 @@
+"""Tests for core Pydantic models."""
+
+from reconcile_bot.core.models import Collaborator, Organization
+
+
+def test_collaborator_defaults() -> None:
+    """Unspecified fields on ``Collaborator`` use sensible defaults."""
+    collab = Collaborator(discord_id=1, name="Alice")
+    assert collab.mission_statement is None
+    assert collab.organization_ids == []
+    assert isinstance(collab.id, str)
+
+
+def test_organization_defaults() -> None:
+    """Unspecified fields on ``Organization`` use sensible defaults."""
+    org = Organization(guild_id=123, name="Guild")
+    assert org.mission_statement is None
+    assert isinstance(org.id, str)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,74 @@
+"""Tests for the ``JSONStorage`` persistence layer."""
+
+from pathlib import Path
+
+from reconcile_bot.core.models import Collaborator, Organization
+from reconcile_bot.core.storage import JSONStorage
+
+
+def test_add_and_get_collaborator(tmp_path: Path) -> None:
+    """Collaborators can be saved and retrieved."""
+    storage = JSONStorage(tmp_path / "data.json")
+    collab = Collaborator(discord_id=42, name="Bob")
+    storage.add_collaborator(collab)
+
+    loaded = storage.get_collaborator_by_discord(42)
+    assert loaded is not None
+    assert loaded.discord_id == 42
+
+
+def test_add_and_get_organization(tmp_path: Path) -> None:
+    """Organizations can be saved and retrieved."""
+    storage = JSONStorage(tmp_path / "data.json")
+    org = Organization(guild_id=999, name="Test Guild")
+    storage.add_organization(org)
+
+    loaded = storage.get_organization_by_guild(999)
+    assert loaded is not None
+    assert loaded.guild_id == 999
+
+
+def test_all_collaborators(tmp_path: Path) -> None:
+    """Iterating returns all saved collaborators."""
+    storage = JSONStorage(tmp_path / "data.json")
+    storage.add_collaborator(Collaborator(discord_id=1, name="Alice"))
+    storage.add_collaborator(Collaborator(discord_id=2, name="Bob"))
+
+    ids = {c.discord_id for c in storage.all_collaborators()}
+    assert ids == {1, 2}
+
+
+def test_get_collaborator_missing(tmp_path: Path) -> None:
+    """Missing collaborator lookups yield ``None``."""
+    storage = JSONStorage(tmp_path / "data.json")
+    assert storage.get_collaborator_by_discord(123) is None
+
+
+def test_all_organizations(tmp_path: Path) -> None:
+    """Iterating returns all saved organizations."""
+    storage = JSONStorage(tmp_path / "data.json")
+    storage.add_organization(Organization(guild_id=1, name="Org1"))
+    storage.add_organization(Organization(guild_id=2, name="Org2"))
+
+    ids = {o.guild_id for o in storage.all_organizations()}
+    assert ids == {1, 2}
+
+
+def test_get_organization_missing(tmp_path: Path) -> None:
+    """Missing organization lookups yield ``None``."""
+    storage = JSONStorage(tmp_path / "data.json")
+    assert storage.get_organization_by_guild(123) is None
+
+
+def test_persistence_across_instances(tmp_path: Path) -> None:
+    """Data survives across multiple storage instances."""
+    path = tmp_path / "data.json"
+    storage = JSONStorage(path)
+    storage.add_collaborator(Collaborator(discord_id=77, name="Eve"))
+    storage.add_organization(Organization(guild_id=88, name="Guild"))
+
+    assert path.exists()
+
+    new_storage = JSONStorage(path)
+    assert new_storage.get_collaborator_by_discord(77) is not None
+    assert new_storage.get_organization_by_guild(88) is not None


### PR DESCRIPTION
## Summary
- implement Pydantic models for Collaborator and Organization
- add JSON-backed storage layer and platform adapter interface
- provide HTTP-based Discord adapter with coverage tests
- document storage and adapter methods and add test docstrings
- expand JSONStorage tests to cover enumeration, missing lookups, and persistence
- exclude test files from Bandit security scans to allow assert-based checks

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_689a56d4df188322b746c6c815e6a54f